### PR TITLE
Fix issue iOS: 2.0.0 has no control buttons! #75

### DIFF
--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -178,10 +178,18 @@
     // NSFoundationVersionNumber_iOS_9_0 = 1240.100000
 
     if (floor(NSFoundationVersionNumber) > 1240.100000) {
-      //only available in iOS 9.1 and up.
-      MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
-      [commandCenter.changePlaybackPositionCommand setEnabled:true];
-      [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changedThumbSliderOnLockScreen:)];
+        //only available in iOS 9.1 and up.
+        MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+        [commandCenter.changePlaybackPositionCommand setEnabled:true];        
+        [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changedThumbSliderOnLockScreen:)];
+        
+        MPRemoteCommandHandlerStatus(^dummyHandler)(MPRemoteCommandEvent *);
+        dummyHandler = ^( MPRemoteCommandEvent * event) {
+            return MPRemoteCommandHandlerStatusSuccess;
+        };
+        [commandCenter.togglePlayPauseCommand addTargetWithHandler:dummyHandler];
+        [commandCenter.nextTrackCommand addTargetWithHandler:dummyHandler];
+        [commandCenter.previousTrackCommand addTargetWithHandler:dummyHandler];
     }
 }
 


### PR DESCRIPTION
It seems that the control center needs to have target handlers enabled to display the prev/back buttons once you set an handler to the position bar. I have set a dummy handler which does nothing and the buttons are popping back.